### PR TITLE
Add package information to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,8 @@
 {
+  "name": "lovata/oc-toolbox-plugin",
+  "type": "october-plugin",
+  "description": "Toolbox plugin for October CMS",
+  "license": "GPL-3.0-only",
   "require": {
     "kharanenka/php-result-store": "2.*",
     "kharanenka/laravel-scope-active": "1.0.*",


### PR DESCRIPTION
Adding composer package information to the composer.json.
This will allow developers or deployment tools to install this package via composer.

If this repository is not registered in [Packagist](https://packagist.org), following is required in the composer.json file of depending project. Its versions are automatically detected from the tags.

```
    "require": {
        ...
    },
    ...
    "repositories": [
        {
            "url": "https://github.com/lovata/oc-toolbox-plugin.git",
            "type": "git"
        }
    ]
```