### PR TITLE
Add comment to property fields

### DIFF
--- a/models/CommonProperty.php
+++ b/models/CommonProperty.php
@@ -469,6 +469,7 @@ class CommonProperty extends ImportModel
             'tab'   => 'lovata.toolbox::lang.tab.properties',
             'span'  => 'left',
             'label' => $this->name,
+            'comment' => $this->description,
         ];
 
         //Get property tab


### PR DESCRIPTION
I like to have means to display a help text (comment) for property field in backend.
I guess using property description for this purpose is reasonable.

<img width="567" alt="screen shot 2019-01-05 at 16 52 55" src="https://user-images.githubusercontent.com/610221/50721910-71e9be80-110a-11e9-8c25-e51ab23bc0f2.png">
