### PR TITLE
Add CachedModel behavior

### DIFF
--- a/behaviors/CachedModel.php
+++ b/behaviors/CachedModel.php
@@ -1,11 +1,11 @@
-<?php namespace Lovata\Toolbox\Classes\Behavior;
+<?php namespace Lovata\Toolbox\Behaviors;
 
 use October\Rain\Extension\ExtensionBase;
 use Lovata\Toolbox\Traits\Helpers\TraitCached;
 
 /**
  * Class CachedModel
- * @package Lovata\Toolbox\Classes\Behavior
+ * @package Lovata\Toolbox\Behaviors
  * @author  Igor Tverdokhleb, i.tverdokhleb@lovata.com, LOVATA Group
  */
 class CachedModel extends ExtensionBase


### PR DESCRIPTION
This will allow you to add CachedTrait to a third party model.

Usage example:
```
ThirdPartyModel::extend(function ($obElement) {
    $obElement->implementClassWith(\Lovata\Toolbox\Behaviors\CachedModel::class);

    $obElement->bindEvent('model.beforeFetch', function() use ($obElement) {
        $obElement->addCachedField([
            'field_1',
            'field_2',
            // ...
        ]);
    });
});
```